### PR TITLE
Fixed bug with list parsing in iocage 1.1

### DIFF
--- a/iocage
+++ b/iocage
@@ -148,7 +148,7 @@ def _get_iocage_facts(module, iocage_path, argument="all", name=None):
                 # non-iocage jails: skip all
                 break
             elif re.match('(\d+|-)',_jid):
-                (_jid,_name,_boot,_state,_type,_release,_ip4,_ip6,_template) = l.split('\t')
+                (_jid,_name,_boot,_state,_type,_release,_ip4,_ip6,_template) = l.split('\t')[:9]
                 if _name != "":
                     _properties = _jail_get_properties(module, iocage_path, _name)
                     _jails[_name] = { "jid": _jid, "name": _name, "state": _state, "properties": _properties }


### PR DESCRIPTION
Limited the number of columns split when running iocage list to
support additional columns added in later version of iocage.