### PR TITLE
Supply proper type so we don't see the warning when you set update=True

### DIFF
--- a/iocage
+++ b/iocage
@@ -486,7 +486,7 @@ def main():
             cmd          = dict(default="", required=False),
             clone_from   = dict(default="", required=False),
             release      = dict(default="", required=False),
-            update       = dict(default="", required=False),
+            update       = dict(default="", required=False, type='bool'),
             components   = dict(default="", aliases=["files","component"], required=False, type='list')),
         supports_check_mode = True
     )


### PR DESCRIPTION
This commit fixes this warning:

```
 [WARNING]: The value True (type bool) in a string field was converted to
u'True' (type string). If this does not look like what you expect, quote the
entire value to ensure it does not change.
```
