### PR TITLE
ignore_errors in test playbook replaced with failed_when

### DIFF
--- a/iocage_test.yml
+++ b/iocage_test.yml
@@ -8,12 +8,13 @@
   tasks:
     - name: Check if release 12.0-RELEASE exists
       iocage: state=fetched release=12.0-RELEASE
-  
+
     - name: Check if basejail exists
       iocage: state=exists name=test_basejail_12_0_RELEASE
-      ignore_errors: true
-  
-#    - name: Check if base jail can be created
+      register: result
+      failed_when: "\"doesn't exist\" not in result.msg"
+
+    #    - name: Check if base jail can be created
 #      iocage: state=basejail name=test_basejail_11_0_RELEASE release=11.0-RELEASE
 #  # Basejails can be made templates
 #    - name: Verify that base jail can be converted
@@ -29,33 +30,34 @@
     - name: Check if template jail can be created
       iocage: state=template name=test_template_12_0_RELEASE release=12.0-RELEASE
       tags:
-      - debug
+        - debug
     - name: Check if template jail can't be started
       iocage: state=started name=test_template_12_0_RELEASE force=yes
-      ignore_errors: yes
+      register: result
+      failed_when: "'Please convert back to a jail' not in result.msg"
     - name: Check if template jail can be force-started
       iocage: state=started name=test_template_12_0_RELEASE force=yes
+      # TODO should this pass or fail?
       ignore_errors: yes
     - name: Check if template jail can be stopped
       iocage: state=stopped name=test_template_12_0_RELEASE
-      ignore_errors: yes
-#    - name: Check if template jail can be destroyed
-#      iocage: state=absent name=test_template_12_0_RELEASE
-  
+
   # check with an absent jail. should produce lots of ignored errors.
-    - name: Check if absent jail can't be destroyed
+    - name: Check if absent jail can be destroyed
       iocage: state=absent name=absent
-      ignore_errors: yes
     - name: Check if absent jail can't be stopped
       iocage: state=stopped name=absent
-      ignore_errors: yes
-    - name: Check if absent jail can be restarted
+      register: result
+      failed_when: "\"doesn't exist\" not in result.msg"
+    - name: Check if absent jail can't be restarted
       iocage: state=restarted name=absent
-      ignore_errors: yes
-    - name: Check if absent jail can be started
+      register: result
+      failed_when: "\"doesn't exist\" not in result.msg"
+    - name: Check if absent jail can't be started
       iocage: state=started name=absent
-      ignore_errors: yes
-  
+      register: result
+      failed_when: "\"doesn't exist\" not in result.msg"
+
   # check everything
     - name: Check if test jail can be created
       iocage: state=present name=test_jail
@@ -65,7 +67,8 @@
       iocage: state=cloned clone_from=test_template_12_0_RELEASE name=test_jail
     - name: Check if pkg info does not work in not-started test jail
       iocage: state=pkg name=test_jail cmd="info"
-      ignore_errors: yes
+      register: result
+      failed_when: "'not running' not in result.msg"
     - name: Check if test jail can be started
       iocage: state=started name=test_jail
     - name: Check if test jail that's started -- is started
@@ -82,6 +85,6 @@
       iocage: state=started name=test_jail
     - name: Check if test jail can be destroyed
       iocage: state=absent name=test_jail
-  
+
     - name: Check if template jail can be destroyed
       iocage: state=absent name=test_template_12_0_RELEASE


### PR DESCRIPTION
Tasks that are supposed to fail now pass.
Please test it on your setup and version before merging.

On FreeBSD 12 and iocage 1.1, step `Check if template jail can be force-started` fails - I think it is correct, since iocage returns in stderr `Please convert back to a jail before trying to start test_template_12_0_RELEASE`, but I left it untouched for now.