### PR TITLE
Fixed length check in facts, fixed update parameter default value

### DIFF
--- a/iocage
+++ b/iocage
@@ -148,10 +148,11 @@ def _get_iocage_facts(module, iocage_path, argument="all", name=None):
                 # non-iocage jails: skip all
                 break
             elif re.match('(\d+|-)',_jid):
-                if l.count('\t') == 10:
-                    (_jid,_name,_boot,_state,_type,_release,_ip4,_ip6,_template,_basejail) = l.split('\t')
+                _fragments = l.split('\t')
+                if len(_fragments) == 10:
+                    (_jid,_name,_boot,_state,_type,_release,_ip4,_ip6,_template,_basejail) = _fragments
                 else:
-                    (_jid,_name,_boot,_state,_type,_release,_ip4,_ip6,_template) = l.split('\t')
+                    (_jid,_name,_boot,_state,_type,_release,_ip4,_ip6,_template) = _fragments
                 if _name != "":
                     _properties = _jail_get_properties(module, iocage_path, _name)
                     _jails[_name] = { "jid": _jid, "name": _name, "state": _state, "properties": _properties }
@@ -504,7 +505,7 @@ def main():
             cmd          = dict(default="", required=False),
             clone_from   = dict(default="", required=False),
             release      = dict(default="", required=False),
-            update       = dict(default="", required=False, type='bool'),
+            update       = dict(default=False, required=False, type='bool'),
             components   = dict(default="", aliases=["files","component"], required=False, type='list')),
         supports_check_mode = True
     )


### PR DESCRIPTION
Fixed broken code from #13 and #14

Not sure how this condition `if l.count('\t') == 10:` could've ever worked, since split have always n-1 delimiter count.
Also fixed `default` for `update` param - python fails on conversion of empty string to boolean.

Please test it on your setup and version before merging. Tested on FreeBSD 12.0 with iocage 1.1.