### PR TITLE
Ensure that 'iocage exec' treats 'cmd' as opaque

### DIFF
--- a/iocage
+++ b/iocage
@@ -300,7 +300,7 @@ def jail_exec(module, iocage_path, name, user="root", cmd='/usr/bin/true'):
     err = ""
     _msg = ""
     if not module.check_mode:
-        rc, out, err = module.run_command("{0} exec -u {1} {2} {3}".format(iocage_path, user, name, cmd))
+        rc, out, err = module.run_command("{0} exec -u {1} {2} -- {3}".format(iocage_path, user, name, cmd))
         if not rc == 0:
             module.fail_json(msg="Command '{0}' could not be executed in jail '{1}'.\nstdout:\n{2}\nstderr:\n{3}".format(cmd, name, out, err))
         _msg = "Command '{0}' was executed in jail '{1}'.\nstdout:\n{2}\nstderr:\n{3}".format(cmd, name, out, err)


### PR DESCRIPTION
When the string provided to 'cmd' for the 'exec' mode
contains options which match iocage's options, iocage
absorbs them instead of passing them along. This patch
adds '--' in the correct position in the 'iocage exec'
command string to ensure that iocage treats
everything afterwards as the command to be executed.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>