### PR TITLE
Apply user-specified properties when creating 'thick' jails

### DIFF
--- a/iocage
+++ b/iocage
@@ -428,8 +428,8 @@ def jail_create(module, iocage_path, name=None, properties={}, clone_from_name=N
             cmd = "{0} create -b -r {2} -n {1}".format(iocage_path, name, release)
 
         elif thickjail:
-            cmd = "{0} create -T -r {2} -n {1}".format(iocage_path, name, release)
-        
+            cmd = "{0} create -T -r {2} -n {1} {3}".format(iocage_path, name, release, _props_to_str(properties))
+
         else:
             cmd = "{0} create -r {2} -n {1} {3}".format(iocage_path, name, release, _props_to_str(properties))
 
@@ -654,9 +654,8 @@ def main():
         elif p["state"] == "basejail":
             properties = {}
             do_basejail = True
-        
+
         elif p["state"] == "thickjail":
-            properties = {}
             do_thickjail = True
 
         elif clone_from:


### PR DESCRIPTION
Thick jails should be treated just like thin jails when they are
created; unlike base or template jails they should have all
user-specified properties applied as they are used as 'normal'
jails once created.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>