### PR TITLE
Make compatible with `iocage list` in iocage v1.2.1 and higher

### DIFF
--- a/iocage.py
+++ b/iocage.py
@@ -274,7 +274,7 @@ def _get_iocage_facts(module, iocage_path, argument="all", name=None):
             if _jid == '---':
                 # non-iocage jails: skip all
                 break
-            elif re.match(r'(\d+|-)', _jid):
+            elif re.match(r'(\d+|-|None)', _jid):
                 _fragments = line.split('\t')
                 if len(_fragments) == 10:
                     (_jid, _name, _boot, _state, _type, _release, _ip4, _ip6, _template, _basejail) = _fragments


### PR DESCRIPTION
Jails that are not running have "None" in the JID column now (since this change:
https://github.com/freebsd/iocage/commit/170047965e7e5a892bb55cf290c0a0d6b892c98a )