### PR TITLE
Added escaping of properties

### DIFF
--- a/iocage.py
+++ b/iocage.py
@@ -374,7 +374,7 @@ def _props_to_str(props):
         elif _val in ['-', 'none']:
             argstr += f"{_prop}={_val} "
         else:
-            argstr += f"{_prop}={str(_val)} "
+            argstr += f'{_prop}="{str(_val)}" '
 
     return argstr
 


### PR DESCRIPTION
Now you could write multiple words in jail properties. Extremely useful with property "notes" ([in iocage doc](https://iocage.readthedocs.io/en/latest/basic-use.html#set-jail-property)) .